### PR TITLE
[Network State Refactoring] Remove page limiter for the comic pager

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,8 +1,5 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
-    <AndroidXmlCodeStyleSettings>
-      <option name="ARRANGEMENT_SETTINGS_MIGRATED_TO_191" value="true" />
-    </AndroidXmlCodeStyleSettings>
     <JetCodeStyleSettings>
       <option name="CODE_STYLE_DEFAULTS" value="KOTLIN_OFFICIAL" />
     </JetCodeStyleSettings>

--- a/.idea/gradle.xml
+++ b/.idea/gradle.xml
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project version="4">
+  <component name="GradleMigrationSettings" migrationVersion="1" />
   <component name="GradleSettings">
     <option name="linkedExternalProjectsSettings">
       <GradleProjectSettings>
+        <option name="testRunner" value="PLATFORM" />
         <option name="distributionType" value="DEFAULT_WRAPPED" />
         <option name="externalProjectPath" value="$PROJECT_DIR$" />
         <option name="modules">
@@ -12,7 +14,6 @@
           </set>
         </option>
         <option name="resolveModulePerSourceSet" value="false" />
-        <option name="testRunner" value="PLATFORM" />
       </GradleProjectSettings>
     </option>
   </component>

--- a/app/src/main/java/com/example/wyrmprint/ui/browse/BrowseFragment.kt
+++ b/app/src/main/java/com/example/wyrmprint/ui/browse/BrowseFragment.kt
@@ -44,8 +44,6 @@ class BrowseFragment : Fragment() {
     private val SPAN_COUNT_PORTRAIT = 2
     private val SPAN_COUNT_LANDSCAPE = 4
 
-    private var onLastPage = false
-
     companion object {
         // Diff config for the comic thumbnail paged model adapter.
         val comicThumbnailDiff = AsyncDifferConfig.Builder<ThumbnailData>(object :
@@ -104,7 +102,6 @@ class BrowseFragment : Fragment() {
             requireActivity().browser_progressBar.visibility = View.GONE
         }
         initObservables(browserViewModel)
-        setDataSourceCallbacks()
     }
 
     private fun createFastAdapter() = GenericFastAdapter.with<IItem<*>, IAdapter<IItem<*>>>(
@@ -143,13 +140,6 @@ class BrowseFragment : Fragment() {
             layoutManager = gridLayoutManager
             // Config adapter
             adapter = fastAdapter
-            addOnScrollListener(object : EndlessRecyclerOnScrollListener(footerItemAdapter) {
-                override fun onLoadMore(currentPage: Int) {
-                    footerItemAdapter.clear()
-                    if (!onLastPage)
-                        footerItemAdapter.add(ProgressItem())
-                }
-            })
         }
     }
 
@@ -176,21 +166,6 @@ class BrowseFragment : Fragment() {
                     } else
                         browsePageItemAdapter.submitList(thumbnailPagedList)
                 })
-            loadedLastPage.observe(viewLifecycleOwner, Observer {
-                if (it) {
-                    onLastPage = it
-                    footerItemAdapter.clear()
-                }
-            })
-        }
-    }
-
-    /**
-     * Set data source callback functions.
-     */
-    private fun setDataSourceCallbacks() {
-        browserViewModel.setOnLoadedMoreThumbnail {
-            browserViewModel.onLastPageLoaded()
         }
     }
 


### PR DESCRIPTION
- Removed progress loader when loading for more comic pages.
- Comic strips #1 and above will now show, in fact all comic strips will be shown.

Note: This push is part of a networking state refactor for paging and RxJava/Kotlin.