### PR TITLE
Feature toggle removal/addition of favorites from the browser section

### DIFF
--- a/app/src/main/java/com/example/wyrmprint/data/database/ComicDatabase.kt
+++ b/app/src/main/java/com/example/wyrmprint/data/database/ComicDatabase.kt
@@ -16,6 +16,12 @@ interface ThumbnailCacheDao {
 
     @Query("DELETE FROM thumbnail_data")
     fun clearThumbnailData()
+
+    @Update
+    fun updateThumbnailData(thumbnailData: ThumbnailData)
+
+    @Query("UPDATE thumbnail_data SET isFavorite = :isFavorite WHERE comicId IN (:comicIdList)")
+    fun updateFavorites(comicIdList: List<Int>, isFavorite: Boolean)
 }
 
 @Dao
@@ -31,6 +37,9 @@ interface ThumbnailFavoritesDao {
 
     @Query("DELETE FROM thumbnail_favorites")
     fun clearThumbnailData()
+
+    @Query("SELECT COUNT() FROM thumbnail_favorites WHERE comicId = :id")
+    fun count(id: Int): Int
 }
 
 @Database(entities = [ThumbnailData::class, ThumbnailFavorite::class], version = 1)

--- a/app/src/main/java/com/example/wyrmprint/data/database/repository/ComicRepository.kt
+++ b/app/src/main/java/com/example/wyrmprint/data/database/repository/ComicRepository.kt
@@ -29,7 +29,12 @@ class ComicRepository @Inject constructor(
      * Return a [ThumbnailDataSourceFactory]
      */
     fun getThumbnailDataSourceFactory() =
-        ThumbnailDataSourceFactory(dragaliaApi, compositeDisposable, thumbnailCacheDao)
+        ThumbnailDataSourceFactory(
+            dragaliaApi,
+            compositeDisposable,
+            thumbnailCacheDao,
+            favoritesDao
+        )
 
     /**
      * Insert the [ThumbnailData] into the favorites table in the database.
@@ -54,5 +59,19 @@ class ComicRepository @Inject constructor(
      */
     fun removeFavoriteComics(favoriteComics: List<ThumbnailFavorite>) {
         favoritesDao.deleteFavoriteRecords(favoriteComics)
+    }
+
+    /**
+     * Update the thumbnail data field in the [thumbnailCacheDao].
+     */
+    fun updateCachedThumbnail(thumbnailData: ThumbnailData) {
+        thumbnailCacheDao.updateThumbnailData(thumbnailData)
+    }
+
+    /**
+     * Update the favorite field of the [ThumbnailData] in the [thumbnailCacheDao]
+     */
+    fun updateThumbnailFavoritesField(comicIdList: List<Int>, isFavorite: Boolean) {
+        thumbnailCacheDao.updateFavorites(comicIdList, isFavorite)
     }
 }

--- a/app/src/main/java/com/example/wyrmprint/data/model/ThumbnailData.kt
+++ b/app/src/main/java/com/example/wyrmprint/data/model/ThumbnailData.kt
@@ -14,7 +14,7 @@ data class ThumbnailData(
     var pageNumber: Int,
     val thumbnailLarge: String,
     val thumbnailSmall: String,
-    var favorite: Boolean = false
+    var isFavorite: Boolean = false
 )
 
 @Entity(tableName = "thumbnail_favorites")
@@ -40,7 +40,8 @@ interface FavoriteUtil {
 /**
  * Wrap a [ThumbnailData] object into a [ThumbnailItemView] and return it.
  */
-fun ThumbnailData.toThumbnailItemView() = ThumbnailItemView(this)
+fun ThumbnailData.toThumbnailItemView() = ThumbnailItemView(this, true)
+    .apply { identifier = this@toThumbnailItemView.comicId.toLong() }
 
 /**
  * Convert thumbnail data to [ThumbnailFavorite] objects.

--- a/app/src/main/java/com/example/wyrmprint/data/remote/pager/ThumbnailDataSourceFactory.kt
+++ b/app/src/main/java/com/example/wyrmprint/data/remote/pager/ThumbnailDataSourceFactory.kt
@@ -3,6 +3,7 @@ package com.example.wyrmprint.data.remote.pager
 import androidx.lifecycle.MutableLiveData
 import androidx.paging.DataSource
 import com.example.wyrmprint.data.database.ThumbnailCacheDao
+import com.example.wyrmprint.data.database.ThumbnailFavoritesDao
 import com.example.wyrmprint.data.model.ThumbnailData
 import com.example.wyrmprint.data.remote.DragaliaLifeApi
 import io.reactivex.disposables.CompositeDisposable
@@ -14,14 +15,20 @@ import javax.inject.Inject
 class ThumbnailDataSourceFactory @Inject constructor(
     private val dragaliaApi: DragaliaLifeApi,
     private val disposables: CompositeDisposable,
-    private val thumbnailCacheDao: ThumbnailCacheDao
+    private val thumbnailCacheDao: ThumbnailCacheDao,
+    private val favoritesDao: ThumbnailFavoritesDao
 ) : DataSource.Factory<Int, ThumbnailData>() {
 
     // The current thumbnail data source that has been created.
     var currThumbnailDataSource = MutableLiveData<ThumbnailComicDataSource>()
 
     override fun create(): DataSource<Int, ThumbnailData> {
-        return ThumbnailComicDataSource(dragaliaApi, disposables, thumbnailCacheDao).apply {
+        return ThumbnailComicDataSource(
+            dragaliaApi,
+            disposables,
+            thumbnailCacheDao,
+            favoritesDao
+        ).apply {
             currThumbnailDataSource.postValue(this)
         }
     }

--- a/app/src/main/java/com/example/wyrmprint/ui/browse/viewholder/ThumbnailItemView.kt
+++ b/app/src/main/java/com/example/wyrmprint/ui/browse/viewholder/ThumbnailItemView.kt
@@ -10,14 +10,32 @@ import com.mikepenz.fastadapter.FastAdapter
 import com.mikepenz.fastadapter.items.AbstractItem
 import com.mikepenz.fastadapter.ui.utils.FastAdapterUIUtils
 
-open class ThumbnailItemView(val thumbnailData: ThumbnailData?) :
+open class ThumbnailItemView(
+    val thumbnailData: ThumbnailData?,
+    autoHighlight: Boolean = false
+) :
     AbstractItem<ThumbnailItemView.ThumbnailCardHolder>() {
     override val layoutRes: Int
         get() = R.layout.thumbnail_item
     override val type: Int
         get() = R.id.thumbnail_image_container
 
+    init {
+        // If the thumbnailData is favorited then automatically "select" the item view.
+        if (autoHighlight)
+            shouldSelectAsFavorite()
+    }
+
     override fun getViewHolder(v: View): ThumbnailCardHolder = ThumbnailCardHolder(v)
+
+    /**
+     * Checks if the [ThumbnailItemView] status should be set as selected.
+     */
+    private fun shouldSelectAsFavorite() {
+        thumbnailData?.apply {
+            isSelected = thumbnailData.isFavorite
+        }
+    }
 
     class ThumbnailCardHolder(view: View) : FastAdapter.ViewHolder<ThumbnailItemView>(view) {
         private val thumbnailImage: ImageView? = view.findViewById(R.id.thumbnail_image)

--- a/app/src/main/java/com/example/wyrmprint/ui/viewmodels/BrowserViewModel.kt
+++ b/app/src/main/java/com/example/wyrmprint/ui/viewmodels/BrowserViewModel.kt
@@ -6,10 +6,10 @@ import androidx.paging.PagedList
 import com.example.wyrmprint.data.database.repository.ComicRepository
 import com.example.wyrmprint.data.model.NetworkStatus
 import com.example.wyrmprint.data.model.ThumbnailData
+import com.example.wyrmprint.data.model.toFavoriteThumbnail
 import com.example.wyrmprint.data.remote.pager.ThumbnailComicDataSource
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.launch
-import kotlinx.coroutines.runBlocking
 import javax.inject.Inject
 
 class BrowserViewModel @Inject constructor(private val comicRepo: ComicRepository) : ViewModel() {
@@ -52,6 +52,19 @@ class BrowserViewModel @Inject constructor(private val comicRepo: ComicRepositor
     fun addToFavorites(thumbnailData: ThumbnailData) {
         viewModelScope.launch(Dispatchers.IO) {
             comicRepo.saveFavoriteComic(thumbnailData)
+            comicRepo.updateCachedThumbnail(thumbnailData)
+        }
+    }
+
+    /**
+     * Remove the thumbnail from the favorites section of the comic repository.
+     *
+     * @param thumbnailData the thumbnail to remove.
+     */
+    fun removeFromFavorites(thumbnailData: ThumbnailData) {
+        viewModelScope.launch(Dispatchers.IO) {
+            comicRepo.removeFavoriteComics(listOf(thumbnailData.toFavoriteThumbnail()))
+            comicRepo.updateCachedThumbnail(thumbnailData)
         }
     }
 }

--- a/app/src/main/java/com/example/wyrmprint/ui/viewmodels/FavoriteViewModel.kt
+++ b/app/src/main/java/com/example/wyrmprint/ui/viewmodels/FavoriteViewModel.kt
@@ -23,6 +23,7 @@ class FavoriteViewModel @Inject constructor(private val comicRepository: ComicRe
     fun removeFavorites(favorites: List<ThumbnailFavorite>) {
         viewModelScope.launch(Dispatchers.IO) {
             comicRepository.removeFavoriteComics(favorites)
+            comicRepository.updateThumbnailFavoritesField(favorites.map { it.comicId }, false)
         }
     }
 }


### PR DESCRIPTION
- Users can now toggle favorites in the browse section by long pressing.
- Thumbnails in the browse section is now properly highlighted when added to  favorites.
- The removal of saved comics strips from the favorites section is now reflected in the browse section. This means that any comics removed from the favorites section will not be highlighted in the browse section.